### PR TITLE
fix: when typing, the order of the messages reverses

### DIFF
--- a/src/components/Chat/ChatInput/index.tsx
+++ b/src/components/Chat/ChatInput/index.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from "react"
+import { addDoc, collection, serverTimestamp } from "firebase/firestore"
+
+import {
+    Content,
+    SendBtn,
+    SendBtnIcon
+} from "./styles"
+
+import Input from "../../Input"
+
+import { auth, databaseApp } from "../../../services/firebaseConfig"
+
+
+const ChatInput: React.FC = () => {
+    const [inputText, setInputText] = useState("")
+
+    const messageRef = collection(databaseApp, "messages")
+    
+    const sendMessage = async (text: string) => {
+        await addDoc(messageRef, {
+            text: text,
+            uid: auth.currentUser?.uid,
+            username: auth.currentUser?.displayName,
+            createdAt: serverTimestamp()
+        })
+    }
+
+    const send = (text: string) => {
+        if (text.trim().length > 0) {
+            sendMessage(text)
+            setInputText("")
+        }
+    }
+
+    return (
+        <Content>
+            <Input
+                placeholder="Digite sua mensagem..."
+                value={inputText}
+                onChange={
+                    (event: React.ChangeEvent<HTMLInputElement>) => setInputText(event.target.value)
+                }
+                onKeyDown={
+                    (event: React.KeyboardEvent<HTMLInputElement>) => {
+                        if (event.key === "Enter" && !event.shiftKey) send(inputText)
+                    }
+                }
+            />
+            <SendBtn>
+                <SendBtnIcon
+                    onClick={
+                        () => send(inputText)
+                    }
+                />
+                </SendBtn>
+        </Content>
+    )
+}
+
+export default ChatInput

--- a/src/components/Chat/ChatInput/styles.ts
+++ b/src/components/Chat/ChatInput/styles.ts
@@ -1,0 +1,40 @@
+import { shade, transparentize } from "polished"
+import { IoMdSend } from "react-icons/io"
+import styled from "styled-components"
+
+
+export const Content = styled.div`
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    background-color: ${props => props.theme.colors.primary};
+    padding: 5px 10px;
+    box-shadow: 0 0 20px 0 ${props => transparentize(0.6, props.theme.colors.shadow)};
+    z-index: 1;
+`
+
+export const SendBtn = styled.div`
+    width: 100%;
+    max-width: 40px;
+    height: 100%;
+    max-height: 40px;
+    border-radius: 50px;
+    background-color: ${props => props.theme.colors.secondary};
+    transition: all 100ms ease;
+
+    &:active {
+        background-color: ${props => shade(0.4, props.theme.colors.secondary)};
+    }
+`
+
+export const SendBtnIcon = styled(IoMdSend)`
+    display: block;
+    fill: ${props => props.theme.colors.iconColor};
+    width: 100%;
+    height: 100%;
+    scale: 0.5;
+    transform: translateX(3px);
+`

--- a/src/components/Chat/index.tsx
+++ b/src/components/Chat/index.tsx
@@ -1,13 +1,11 @@
-import React, { useState } from "react"
+import React from "react"
 import { NavigateFunction, useNavigate } from "react-router-dom"
 import {
     DocumentData,
-    addDoc,
     collection,
     limit,
     orderBy,
-    query,
-    serverTimestamp
+    query
 } from "firebase/firestore"
 import { useCollectionData } from "react-firebase-hooks/firestore"
 import { IDOptions, InitialValueOptions } from "react-firebase-hooks/firestore/dist/firestore/types"
@@ -15,14 +13,11 @@ import { IDOptions, InitialValueOptions } from "react-firebase-hooks/firestore/d
 import {
     Avatar,
     Content,
-    InputContent,
-    SendBtn,
-    SendBtnIcon,
     SettingsIcon
 } from "./styles"
 
-import Input from "../Input"
 import Header from "../Header"
+import ChatInput from "./ChatInput"
 import ScreenTitle from "../ScreenTitle"
 import LeftHeader from "../Header/LeftHeader"
 import RightHeader from "../Header/RightHeader"
@@ -34,25 +29,7 @@ import { auth, databaseApp } from "../../services/firebaseConfig"
 const Chat: React.FC = () => {
     const navigate: NavigateFunction = useNavigate()
 
-    const [text, setText] = useState("")
-    
     const messageRef = collection(databaseApp, "messages")
-
-    const sendMessage = async (text: string) => {
-            await addDoc(messageRef, {
-                text: text,
-                uid: auth.currentUser?.uid,
-                username: auth.currentUser?.displayName,
-                createdAt: serverTimestamp()
-            })
-        }
-
-    const send = (text: string) => {
-        if (text.trim().length > 0) {
-            sendMessage(text)
-            setText("")
-        }
-    }
         
     const queryMessages = query(
         messageRef,
@@ -79,27 +56,7 @@ const Chat: React.FC = () => {
                 </RightHeader>
             </Header>
             <Messages messages={messages?.reverse()!}/>
-            <InputContent>
-                <Input
-                    placeholder="Digite sua mensagem..."
-                    value={text}
-                    onChange={
-                        (event: React.ChangeEvent<HTMLInputElement>) => setText(event.target.value)
-                    }
-                    onKeyDown={
-                        (event: React.KeyboardEvent<HTMLInputElement>) => {
-                            if (event.key === "Enter" && !event.shiftKey) send(text)
-                        }
-                    }
-                />
-                <SendBtn>
-                    <SendBtnIcon
-                        onClick={
-                            () => send(text)
-                        }
-                    />
-                    </SendBtn>
-            </InputContent>
+            <ChatInput />
         </Content>
     )
 }

--- a/src/components/Chat/styles.ts
+++ b/src/components/Chat/styles.ts
@@ -1,6 +1,6 @@
-import { shade, transparentize } from "polished"
+import { transparentize } from "polished"
 import styled from "styled-components"
-import { IoMdSend, IoMdSettings } from "react-icons/io"
+import { IoMdSettings } from "react-icons/io"
 
 
 export const Content = styled.div`
@@ -25,40 +25,4 @@ export const Avatar = styled.img`
     width: 42px;
     height: 42px;
     border-radius: 50px;
-`
-
-export const InputContent = styled.div`
-    width: 100%;
-    height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 10px;
-    background-color: ${props => props.theme.colors.primary};
-    padding: 5px 10px;
-    box-shadow: 0 0 20px 0 ${props => transparentize(0.6, props.theme.colors.shadow)};
-    z-index: 1;
-`
-
-export const SendBtn = styled.div`
-    width: 100%;
-    max-width: 40px;
-    height: 100%;
-    max-height: 40px;
-    border-radius: 50px;
-    background-color: ${props => props.theme.colors.secondary};
-    transition: all 100ms ease;
-
-    &:active {
-        background-color: ${props => shade(0.4, props.theme.colors.secondary)};
-    }
-`
-
-export const SendBtnIcon = styled(IoMdSend)`
-    display: block;
-    fill: ${props => props.theme.colors.iconColor};
-    width: 100%;
-    height: 100%;
-    scale: 0.5;
-    transform: translateX(3px);
 `


### PR DESCRIPTION
In the commit of the new organization of the components (#10), there was a bug where the history of the messages inverted when typing. This happened because `useState` re-rendered the parent component, reapplying the `.reverse()` method on the message array. To correct this, a new component called `ChatInput` was created, containing the input bar and its buttons.

Highlight updates when components render, using React DevTools:

| After the new organization | Before the new organization |
| -------------------------- | --------------------------- |
| <img src="https://github.com/Lobooooooo14/Arroz-Chat/assets/88998991/93553c5a-c87e-4a1a-85a8-9af105292f92" width="400"> | <img src="https://github.com/Lobooooooo14/Arroz-Chat/assets/88998991/7cafc78a-15d8-4750-8b0b-a53f9cecba85" width="400"> |
